### PR TITLE
update assessments to identify failed tests

### DIFF
--- a/R-IQ-OQ.Rnw
+++ b/R-IQ-OQ.Rnw
@@ -1079,7 +1079,15 @@ above output should be reviewed in detail to determine their relevance to the Op
 # Get results from system() calls above
 SystemResults <- list(Result1, Result2, Result3, Result4, Result5, Result6, Result7)
 SystemResults <- sapply(SystemResults, 
-                        function(x) if (class(x) == "try-error") "\\\\textcolor{Red}{FAIL}" else "\\\\textcolor{ForestGreen}{PASS}")
+                        function(x) {
+                          if (class(x) == "try-error") {
+                            "\\\\textcolor{Red}{FAIL}"
+                          } else if(x != 0L) {
+                            "\\\\textcolor{Red}{FAIL}"
+                          } else {
+                            "\\\\textcolor{ForestGreen}{PASS}"
+                          }
+                        })
                         
 # Get results from files created during CMDFileX execution if failures are found
 ResultFileNames <- paste("/IQ-OQ-TestOutput/CMDFile", 1:7, "Fail", sep = "")


### PR DESCRIPTION
When `system` is used to execute R CMD BATCH (i.e., `Result6 <- try(system(CMD))`), if the R script being executed fails, the class of `Result6` is not `"try-error"`. According to the docs for `system`: If intern = FALSE, the return value is an error code (0 for success).